### PR TITLE
feat(either): introduce either.tap()

### DIFF
--- a/src/interfaces/either.interface.ts
+++ b/src/interfaces/either.interface.ts
@@ -2,6 +2,7 @@ export interface IEither<L, R> {
   isLeft(): boolean
   isRight(): boolean
   match<T>(pattern: IEitherPattern<L, R, T>): T
+  tap<T>(pattern: Partial<IEitherPattern<L, R, T>>): void
   map<T>(f: (r: R) => T): IEither<L, T>
   flatMap<T>(f: (r: R) => IEither<L, T>): IEither<L, T>
 }

--- a/src/monads/either.ts
+++ b/src/monads/either.ts
@@ -38,6 +38,11 @@ export function either<L, R>(left?: L, right?: R): IEither<L, R> {
         ? pattern.right(right as R)
         : pattern.left(left as L)
     },
+    tap<T>(pattern: Partial<IEitherPattern<L, R, T>>) {
+      exists(right)
+        ? pattern.right && pattern.right(right as R)
+        : pattern.left && pattern.left(left as L)
+    },
     map<T>(f: (r: R) => T) {
       return exists(right)
         ? either<L, T>(undefined, f(right as R))

--- a/test/monads/either.spec.ts
+++ b/test/monads/either.spec.ts
@@ -119,4 +119,67 @@ describe(either.name, () => {
 
     expect(mapped).toEqual(3)
   })
+
+  it('should tap left', () => {
+    expect.assertions(6)
+
+    const input1 = 123
+    const input2: number | undefined = undefined
+
+    const eitherThing = either(input1, input2)
+
+    const mapped1 = eitherThing
+      .tap({
+        right: _rightSideEffect => fail(),
+        left: leftSideEffect => {
+          expect(leftSideEffect).toEqual(123)
+        }
+      })
+
+    const mapped2 = eitherThing
+      .tap({
+        left: leftSideEffect => expect(leftSideEffect).toEqual(123)
+      })
+    const mapped3 = eitherThing
+      .tap({
+        right: _rightSideEffect => fail()
+      })
+
+    const mapped4 = eitherThing.tap({})
+
+    expect(mapped1).toEqual(undefined)
+    expect(mapped2).toEqual(undefined)
+    expect(mapped3).toEqual(undefined)
+    expect(mapped4).toEqual(undefined)
+  })
+
+  it('should tap right', () => {
+    expect.assertions(6)
+
+    const input1 = undefined
+    const input2: number | undefined = 123
+
+    const eitherThing = either(input1, input2)
+
+    const mapped1 = eitherThing
+      .tap({
+        left: _leftSideEffect => fail(),
+        right: rightSideEffect => expect(rightSideEffect).toEqual(123)
+      })
+
+    const mapped2 = eitherThing
+      .tap({
+        left: _leftSideEffect => fail()
+      })
+    const mapped3 = eitherThing
+      .tap({
+        right: rightSideEffect => expect(rightSideEffect).toEqual(123)
+      })
+    const mapped4 = eitherThing.tap({})
+
+    expect(mapped1).toEqual(undefined)
+    expect(mapped2).toEqual(undefined)
+    expect(mapped3).toEqual(undefined)
+    expect(mapped4).toEqual(undefined)
+  })
 })


### PR DESCRIPTION
Allows functions to be executed as side effects without return values. Similar to .map()