### PR TITLE
feat(package): add commonjs and es modules using rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -663,6 +663,36 @@
         "@types/node": ">= 8"
       }
     },
+    "@rollup/plugin-typescript": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-3.0.0.tgz",
+      "integrity": "sha512-O6915Ril3+Q0B4P898PULAcPFZfPuatEB/4nox7bnK48ekGrmamMYhMB5tOqWjihEWrw4oz/NL+c+/kS3Fk95g==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.1",
+        "resolve": "^1.14.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+          "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.8.tgz",
+      "integrity": "sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^1.0.1"
+      }
+    },
     "@semantic-release/commit-analyzer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
@@ -2304,6 +2334,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "typescript-monads",
   "version": "0.0.0-development",
   "description": "Write cleaner TypeScript",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "commonJs": "dist/index.cjs.js",
+  "typings": "dist/types/index.d.ts",
   "author": "Patrick Michalina <patrickmichalina@mac.com> (https://patrickmichalina.com)",
   "license": "MIT",
   "repository": {
@@ -24,12 +27,13 @@
     "dist": "ts-node ./scripts/publish-prep.ts",
     "lint": "tslint --project tsconfig.json --config tslint.json",
     "build": "tsc -p tsconfig.build.json && npm run rollup && terser dist/index.js -o dist/index.min.js --source-map",
-    "rollup": "rollup dist/index.js -o dist/index.js --format umd --name \"typescriptMonads\" -m"
+    "rollup": "rollup -c rollup.config.js"
   },
   "release": {
     "pkgRoot": "dist"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^3.0.0",
     "@types/fs-extra": "^8.0.1",
     "@types/jest": "^25.1.1",
     "@types/node": "^13.7.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ export default [
   {
     input: 'dist/index.js',
     output: {
-      name: 'typescriptMonads',
+      name: 'monads',
       file: pkg.main,
       format: 'umd',
       sourcemap: true

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,21 @@
+import typescript from '@rollup/plugin-typescript'
+import pkg from './package.json'
+
+export default [
+  {
+    input: 'dist/index.js',
+    output: {
+      name: 'typescriptMonads',
+      file: pkg.main,
+      format: 'umd',
+      sourcemap: true
+    },
+  },
+  {
+  input: 'src/index.ts',
+  output: [
+    { file: pkg.module, format: 'es', sourcemap: true },
+    { file: pkg.commonJs, format: 'cjs', sourcemap: true }
+  ],
+  plugins: [typescript()]
+}]

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,4 +1,4 @@
-export { IEither, IEitherPattern } from './either.interface'
-export { IMaybe, IMaybePattern } from './maybe.interface'
-export { mapping, IMonad } from './monad.interface'
-export { IReader } from './reader.interface'
+export * from './either.interface'
+export * from './maybe.interface'
+export * from './monad.interface'
+export * from './reader.interface'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "lib": ["es2015", "dom"],
-    "outDir": "dist",
+    "outDir": "dist/lib",
     "isolatedModules": false,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
@@ -22,6 +22,8 @@
     "strictFunctionTypes": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
+    "declarationDir": "dist/types",
+    "declarationMap": true,
     "sourceMap": true
   },
   "include": [


### PR DESCRIPTION
Providing these modern bundle formats should help increase library adoption. This more modular
approach will allow developers to shake out unused functions using the bundler in their project as
well. Note that some interface exports were made starry because of a limitation of the typescript
plugin. The use of that plugin does resolve an issue with the build related to spread operator
polyfilling (for cjs bundles, anyway). There should be no breaking changes since the UMD module output is still marked as
main, and the name of the module hasn't changed.