### PR TITLE
chore(package): mark the package side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "dist/index.esm.js",
   "commonJs": "dist/index.cjs.js",
   "typings": "dist/types/index.d.ts",
+  "sideEffects": false,
   "author": "Patrick Michalina <patrickmichalina@mac.com> (https://patrickmichalina.com)",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This will hint to bundlers that files can be cleanly pruned.