### PR TITLE
fix(build): correct bundle path for common and es modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "tslint-immutable": "^6.0.1",
     "typescript": "^3.7.5"
   },
+  "peerDependencies": {
+    "tslib": "^1.10.0"
+  },
   "jest": {
     "testURL": "http://localhost",
     "collectCoverage": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "module": "index.esm.js",
   "commonJs": "index.cjs.js",
-  "typings": "types/index.d.ts",
+  "typings": "index.d.ts",
   "sideEffects": false,
   "author": "Patrick Michalina <patrickmichalina@mac.com> (https://patrickmichalina.com)",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,11 @@
 import typescript from '@rollup/plugin-typescript'
 import pkg from './package.json'
 
+const path = require('path')
+
 export default [
   {
-    input: 'dist/lib/index.js',
+    input: 'dist/index.js',
     output: {
       name: 'monads',
       file: `dist/${pkg.main}`,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,6 @@
 import typescript from '@rollup/plugin-typescript'
 import pkg from './package.json'
 
-const path = require('path')
-
 export default [
   {
     input: 'dist/index.js',

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "lib": ["es2015", "dom"],
-    "outDir": "dist/lib",
+    "outDir": "dist",
     "isolatedModules": false,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
@@ -22,7 +22,7 @@
     "strictFunctionTypes": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "dist",
     "declarationMap": true,
     "sourceMap": true
   },


### PR DESCRIPTION
I didn't realize that the entire behavior of the typescript plugin for rollup had changed so
drastically in version 3. It used to produce a complete bundle, but now exports from other compiled
files, which means the path will be incorrect if the bundle isn't in the same directory. An
alternative to this approach would be to move the es and common module bundles into the lib
directory, but this would probably break typing, so it seems like the best approach is to keep the
compiled source at the root level. It seems simpler this way.

Also adds `tslib` as a `peerDependency`. It's only needed when bundling the library into another library, but not while developing the library since `tslib` is installed via one of the `devDependencies`.