### PR TITLE
feat: add flatMapMaybe method to handle optional transformations

### DIFF
--- a/src/maybe/maybe.interface.ts
+++ b/src/maybe/maybe.interface.ts
@@ -2,145 +2,437 @@ import { IMonad } from '../monad/monad.interface'
 import { IResult } from '../result/result.interface'
 
 /**
- * Define a contract to unwrap Maybe object
+ * Defines a pattern matching contract for unwrapping Maybe objects.
+ * 
+ * This interface provides separate handlers for the Some and None states,
+ * enabling exhaustive case analysis when working with Maybe values.
+ * 
+ * @typeParam TIn - The type of value contained in the Maybe
+ * @typeParam TOut - The type of value returned by the pattern matching functions
  */
 export interface IMaybePattern<TIn, TOut> {
   /**
-   * Function to handle when a value exists.
+   * Function to handle when a value exists (Some case).
+   * 
+   * @param val - The non-null, non-undefined value contained in the Maybe
+   * @returns A value of type TOut
    */
   some(val: NonNullable<TIn>): TOut
 
   /**
-   * Function to handle when a value is undefined.
+   * Function to handle when a value is null or undefined (None case).
+   * 
+   * @returns A value of type TOut
    */
   none(): TOut
 }
 
 /**
- * Abstraction for handling possibility of undefined or null values
+ * A monad that represents optional values, handling the possibility of undefined or null values.
+ * 
+ * The Maybe monad provides a safe way to work with values that might not exist without
+ * explicitly checking for null/undefined at every step. It encapsulates common patterns
+ * for handling optional values and enables fluent, chainable operations.
+ * 
+ * There are two states of Maybe:
+ * - Some: Contains a non-null, non-undefined value
+ * - None: Represents the absence of a value (null or undefined)
+ * 
+ * @typeParam T - The type of the value that may be present
  */
 export interface IMaybe<T> extends IMonad<T> {
 
+  /**
+   * Creates a new Maybe instance containing the provided value.
+   * 
+   * @param x - The value to wrap in a Maybe
+   * @returns A new Maybe containing the value
+   * 
+   * @example
+   * const maybeNumber = maybe.of(42);
+   * // Creates a Some Maybe containing 42
+   */
   of(x: T): IMaybe<T>
 
   /**
-   * Unwrap a Maybe with a default value
+   * Unwraps a Maybe, returning the contained value if present, or a default value if empty.
+   * 
+   * @param val - The default value to return if this Maybe is None
+   * @returns The contained value if this Maybe is Some, otherwise the provided default value
+   * 
+   * @example
+   * const value = maybe(user.email).valueOr('no-email@example.com');
+   * // Returns the user's email if it exists, otherwise returns the default string
    */
   valueOr(val: NonNullable<T>): T
 
   /**
-   * Unwrap a Maybe with its value or return undefined if its empty
+   * Unwraps a Maybe, returning the contained value if present, or undefined if empty.
+   * 
+   * @returns The contained value if this Maybe is Some, otherwise undefined
+   * 
+   * @example
+   * const email = maybe(user.email).valueOrUndefined();
+   * // Returns the email if it exists, otherwise undefined
+   * 
+   * // Useful for optional chaining compatibility
+   * const optionalValue = maybe(obj.deep.nested.property).valueOrUndefined();
    */
   valueOrUndefined(): T | undefined
 
   /**
-   * Unwrap a Maybe with its value or return null if its empty
+   * Unwraps a Maybe, returning the contained value if present, or null if empty.
+   * 
+   * @returns The contained value if this Maybe is Some, otherwise null
+   * 
+   * @example
+   * const email = maybe(user.email).valueOrNull();
+   * // Returns the email if it exists, otherwise null
    */
   valueOrNull(): T | null
 
   /**
-   * Unwrap a Maybe with its value or return and empty list
+   * Converts a Maybe to a readonly array containing either the value or nothing.
+   * 
+   * @returns An array with the contained value if this Maybe is Some, otherwise an empty array
+   * 
+   * @example
+   * const emails = maybe(user.email).toArray();
+   * // Returns [email] if email exists, otherwise []
+   * 
+   * // Useful for functional operations on arrays
+   * const allEmails = users
+   *   .map(user => maybe(user.email).toArray())
+   *   .flat();
+   * // Creates an array of only the non-null/undefined emails
    */
   toArray(): ReadonlyArray<T>
 
   /**
-   * Unwrap a Maybe with a default computed value
+   * Unwraps a Maybe with a lazily computed default value.
+   * 
+   * Similar to valueOr, but the default value is computed only when needed,
+   * which can be more efficient when the default is expensive to compute.
+   * 
+   * @param f - A function that returns the default value if this Maybe is None
+   * @returns The contained value if this Maybe is Some, otherwise the result of calling f
+   * 
+   * @example
+   * const cachedData = maybe(cache.get(key))
+   *   .valueOrCompute(() => {
+   *     const data = expensiveOperation();
+   *     cache.set(key, data);
+   *     return data;
+   *   });
+   * // Only performs the expensive operation if the cache is empty
    */
   valueOrCompute(f: () => NonNullable<T>): T
 
   /**
-   * Unwrap a Maybe with the final value or throw an error
+   * Unwraps a Maybe, returning the contained value if present, or throwing an error with the specified message.
+   * 
+   * @param msg - Optional custom error message to use when throwing an error
+   * @returns The contained value if this Maybe is Some
+   * @throws Error with the provided message (or a default message) if this Maybe is None
+   * 
+   * @example
+   * const email = maybe(user.email).valueOrThrow('Email is required');
+   * // Returns the email if it exists, otherwise throws an Error with the message "Email is required"
    */
   valueOrThrow(msg?: string): T
 
   /**
-   * Unwrap a Maybe with the final value or throw an error
+   * Unwraps a Maybe, returning the contained value if present, or throwing the specified error.
+   * 
+   * @param err - Optional custom error instance to throw
+   * @returns The contained value if this Maybe is Some
+   * @throws The provided Error (or a default Error) if this Maybe is None
+   * 
+   * @example
+   * const email = maybe(user.email).valueOrThrowErr(new ValidationError('Email is required'));
+   * // Returns the email if it exists, otherwise throws the ValidationError
    */
   valueOrThrowErr(err?: Error): T
 
   /**
-   * Execute functions with side-effects.
+   * Executes side-effect functions based on the state of the Maybe without changing the Maybe.
+   * 
+   * This is useful for logging, debugging, or performing other side effects
+   * without affecting the Maybe chain.
+   * 
+   * @param val - An object with some/none functions to execute based on the Maybe state
+   * 
+   * @example
+   * maybe(user.email)
+   *   .tap({
+   *     some: email => console.log(`Found email: ${email}`),
+   *     none: () => console.log('No email found')
+   *   });
+   * // Logs appropriate message but doesn't change the Maybe value
    */
   tap(val: Partial<IMaybePattern<T, void>>): void
 
   /**
-   * Execute a function with side-effects when maybe is a none.
+   * Executes a side-effect function when the Maybe is None.
+   * 
+   * @param f - Function to execute if this Maybe is None
+   * 
+   * @example
+   * maybe(user.email)
+   *   .tapNone(() => analytics.track('Missing Email'));
+   * // Tracks analytics event only if email is missing
    */
   tapNone(f: () => void): void
 
   /**
-   * Execute a function with side-effects when maybe is a some.
+   * Executes a side-effect function when the Maybe is Some.
+   * 
+   * @param f - Function to execute with the value if this Maybe is Some
+   * 
+   * @example
+   * maybe(user.email)
+   *   .tapSome(email => console.log(`Working with email: ${email}`));
+   * // Logs message only if email exists
    */
   tapSome(f: (val: T) => void): void
 
   /**
-   * Execute functions with side-effects.
+   * Executes side-effect functions based on the state of the Maybe and returns the original Maybe.
+   * 
+   * Similar to tap, but returns the Maybe to enable further chaining.
+   * 
+   * @param val - An object with some/none functions to execute based on the Maybe state
+   * @returns This Maybe unchanged, allowing for continued chaining
+   * 
+   * @example
+   * const processedEmail = maybe(user.email)
+   *   .tapThru({
+   *     some: email => console.log(`Found email: ${email}`),
+   *     none: () => console.log('No email found')
+   *   })
+   *   .map(email => email.toLowerCase());
+   * // Logs appropriate message and continues the chain
    */
   tapThru(val: Partial<IMaybePattern<T, void>>): IMaybe<T>
 
   /**
-   * Execute a function with side-effects when maybe is a none.
+   * Executes a side-effect function when the Maybe is None and returns the original Maybe.
+   * 
+   * @param f - Function to execute if this Maybe is None
+   * @returns This Maybe unchanged, allowing for continued chaining
+   * 
+   * @example
+   * const processedEmail = maybe(user.email)
+   *   .tapThruNone(() => analytics.track('Missing Email'))
+   *   .valueOr('default@example.com');
+   * // Tracks analytics event if email is missing and continues the chain
    */
   tapThruNone(f: () => void): IMaybe<T>
 
   /**
-   * Execute a function with side-effects when maybe is a some.
+   * Executes a side-effect function when the Maybe is Some and returns the original Maybe.
+   * 
+   * @param f - Function to execute with the value if this Maybe is Some
+   * @returns This Maybe unchanged, allowing for continued chaining
+   * 
+   * @example
+   * const processedEmail = maybe(user.email)
+   *   .tapThruSome(email => analytics.track('Email Found', { email }))
+   *   .map(email => email.toLowerCase());
+   * // Tracks analytics event if email exists and continues the chain
    */
   tapThruSome(f: (val: T) => void): IMaybe<T>
 
   /**
-   * Unwrap and apply MaybePattern functions
+   * Performs pattern matching on the Maybe, applying different functions based on its state.
+   * 
+   * This is the primary way to exhaustively handle both Some and None cases with different logic.
+   * 
+   * @typeParam R - The return type of the pattern matching functions
+   * @param pattern - An object with functions for handling Some and None cases
+   * @returns The result of applying the appropriate function from the pattern
+   * 
+   * @example
+   * const greeting = maybe(user.name).match({
+   *   some: name => `Hello, ${name}!`,
+   *   none: () => 'Hello, guest!'
+   * });
+   * // Returns personalized greeting if name exists, otherwise generic greeting
    */
   match<R>(pattern: IMaybePattern<T, R>): R
 
   /**
-   * Map output of non-empty data to a new value
+   * Transforms the value inside a Some Maybe using the provided function.
+   * 
+   * If the Maybe is None, it remains None. This follows the standard functor pattern.
+   * 
+   * @typeParam R - The type of the transformed value
+   * @param f - A function to transform the contained value
+   * @returns A new Maybe containing the transformed value if this Maybe is Some, otherwise None
+   * 
+   * @example
+   * const upperEmail = maybe(user.email)
+   *   .map(email => email.toUpperCase());
+   * // Contains uppercase email if email exists, otherwise None
    */
   map<R>(f: (t: T) => NonNullable<R>): IMaybe<R>
 
   /**
-   * Map to a new value while ignoring previous output value but respecting maybeness
+   * Replaces the value inside a Some Maybe with a new value.
+   * 
+   * If the Maybe is None, it remains None. This is a shorthand for map that ignores the current value.
+   * 
+   * @typeParam R - The type of the new value
+   * @param v - The new value to use if this Maybe is Some
+   * @returns A new Maybe containing the new value if this Maybe is Some, otherwise None
+   * 
+   * @example
+   * const defaultEmail = maybe(user.hasEmail)
+   *   .mapTo('default@example.com');
+   * // Contains 'default@example.com' if hasEmail is true, otherwise None
    */
   mapTo<R>(v: NonNullable<R>): IMaybe<R>
 
   /**
-   * Returns true if value is not empty
+   * Checks if this Maybe contains a value (is in the Some state).
+   * 
+   * This is a type guard that helps TypeScript narrow the type when used in conditionals.
+   * 
+   * @returns true if this Maybe is Some, false if it is None
+   * 
+   * @example
+   * const maybeEmail = maybe(user.email);
+   * if (maybeEmail.isSome()) {
+   *   // TypeScript knows maybeEmail has a value here
+   *   sendEmail(maybeEmail.valueOrThrow());
+   * }
    */
   isSome(): boolean
 
   /**
-   * Return true if value is empty
+   * Checks if this Maybe is empty (is in the None state).
+   * 
+   * This is a type guard that helps TypeScript narrow the type when used in conditionals.
+   * 
+   * @returns true if this Maybe is None, false if it is Some
+   * 
+   * @example
+   * const maybeEmail = maybe(user.email);
+   * if (maybeEmail.isNone()) {
+   *   // TypeScript knows maybeEmail is None here
+   *   promptForEmail();
+   * }
    */
   isNone(): boolean
 
   /**
-   * Combine multiple Maybe
+   * Chains Maybe operations by applying a function that returns a new Maybe.
+   * 
+   * This is the core monadic binding operation (>>=) that allows composing operations
+   * that might fail. If this Maybe is None, the function is not called.
+   * 
+   * @typeParam R - The type of value in the new Maybe
+   * @param f - A function that takes the value from this Maybe and returns a new Maybe
+   * @returns The result of applying f to the value if this Maybe is Some, otherwise None
+   * 
+   * @example
+   * const userCity = maybe(user.profile)
+   *   .flatMap(profile => maybe(profile.address))
+   *   .flatMap(address => maybe(address.city));
+   * // Safely navigates nested optional properties
    */
   flatMap<R>(f: (t: T) => IMaybe<R>): IMaybe<R>
 
   /**
-   * Combine multiple Maybe, automatically wrapping predicate
+   * Chains Maybe operations with automatic wrapping of the result in a Maybe.
+   * 
+   * Similar to flatMap, but the function returns a raw value that will be
+   * automatically wrapped in a Maybe. Null/undefined results become None.
+   * 
+   * @typeParam R - The type of value returned by the function
+   * @param fn - A function that takes the value from this Maybe and returns a value (or null/undefined)
+   * @returns A Maybe containing the result of applying fn if non-null/undefined, otherwise None
+   * 
+   * @example
+   * const userName = maybe(user)
+   *   .flatMapAuto(u => u.profile?.name);
+   * // Returns Some(name) if user and profile exist and name is non-null, otherwise None
    */
   flatMapAuto<R>(fn: (v: NonNullable<T>) => R): IMaybe<NonNullable<R>>
 
   /**
-   * drill into Just values
+   * Projects a property or derived value from the contained value.
+   * 
+   * This is a convenient way to access nested properties without explicit
+   * mapping. Null/undefined results become None.
+   * 
+   * @typeParam R - The type of the projected value
+   * @param fn - A function that extracts a property or computes a value from the contained value
+   * @returns A Maybe containing the projected value if non-null/undefined, otherwise None
+   * 
+   * @example
+   * interface User {
+   *   name: string;
+   *   email: string;
+   * }
+   * 
+   * const userName = maybe(user)
+   *   .project(u => u.name);
+   * // Extracts the name property from user if it exists
    */
   project<R extends T[keyof T]>(fn: (d: NonNullable<T>) => R): IMaybe<NonNullable<R>>
 
   /**
-   * Apply a predicate which if met, continues the Maybe chain,
-   * otherwise return an empty Maybe
+   * Filters a Maybe based on a predicate function.
+   * 
+   * If the predicate returns true, the Maybe remains unchanged.
+   * If the predicate returns false, the Maybe becomes None.
+   * 
+   * @param fn - A predicate function that tests the contained value
+   * @returns This Maybe if it is None or if the predicate returns true, otherwise None
+   * 
+   * @example
+   * const validEmail = maybe(user.email)
+   *   .filter(email => email.includes('@'));
+   * // Contains the email only if it includes @, otherwise None
    */
   filter(fn: (t: T) => boolean): IMaybe<T>
 
   /**
-   * Apply a function wrapped in Maybe
+   * Applies a wrapped function to the value in this Maybe.
+   * 
+   * This implements the applicative functor pattern, allowing functions
+   * wrapped in a Maybe to be applied to values wrapped in a Maybe.
+   * 
+   * @typeParam R - The return type of the wrapped function
+   * @param fab - A Maybe containing a function to apply to the value in this Maybe
+   * @returns A Maybe containing the result of applying the function to the value if both are Some, otherwise None
+   * 
+   * @example
+   * const validateEmail = (email: string) => email.includes('@') ? email : null;
+   * const maybeValidate = maybe(validateEmail);
+   * const maybeEmail = maybe(user.email);
+   * 
+   * const validatedEmail = maybeEmail.apply(maybeValidate.map(f => (email: string) => f(email)));
+   * // Contains the email if both the validation function and email exist and validation passes
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // apply(maybe: IMaybe<ReturnType<T extends (...args: any) => any ? T : any>>): IMaybe<T>
-
   apply<R>(fab: IMaybe<(t: T) => R>): IMaybe<R>
 
+  /**
+   * Converts a Maybe to a Result monad.
+   * 
+   * This is useful when you need to transition from an optional value (Maybe)
+   * to an explicit success/failure model (Result) with a specific error.
+   * 
+   * @typeParam E - The error type for the Result
+   * @param error - The error value to use if this Maybe is None
+   * @returns An Ok Result containing the value if this Maybe is Some, otherwise a Fail Result with the error
+   * 
+   * @example
+   * const user = maybe(findUser(id))
+   *   .toResult(new Error('User not found'))
+   *   .map(user => processUser(user));
+   * // Converts a Maybe<User> to a Result<User, Error>
+   */
   toResult<E>(error: E): IResult<T, E>
 }

--- a/src/result/result.interface.ts
+++ b/src/result/result.interface.ts
@@ -8,16 +8,366 @@ export interface IResultMatchPattern<T, E, U> {
 }
 
 export interface IResult<T, E> {
+  /**
+   * Type guard that determines if this Result is an Ok variant.
+   * 
+   * This method acts as a TypeScript type guard, narrowing the type of the Result
+   * when used in conditional blocks.
+   * 
+   * @returns true if this Result is an Ok variant, false otherwise
+   * 
+   * @example
+   * const result = getUser(userId);
+   * 
+   * if (result.isOk()) {
+   *   // TypeScript knows that result is an Ok variant here
+   *   const user = result.unwrap(); // Safe to call
+   *   console.log(user.name);
+   * } else {
+   *   // TypeScript knows that result is a Fail variant here
+   *   const error = result.unwrapFail(); // Safe to call
+   *   console.error(error.message);
+   * }
+   */
   isOk(): boolean
+  /**
+   * Type guard that determines if this Result is a Fail variant.
+   * 
+   * This method acts as a TypeScript type guard, narrowing the type of the Result
+   * when used in conditional blocks.
+   * 
+   * @returns true if this Result is a Fail variant, false otherwise
+   * 
+   * @example
+   * const result = authenticate(credentials);
+   * 
+   * if (result.isFail()) {
+   *   // TypeScript knows that result is a Fail variant here
+   *   const error = result.unwrapFail(); // Safe to call
+   *   handleAuthError(error);
+   * } else {
+   *   // TypeScript knows that result is an Ok variant here
+   *   startSession(result.unwrap()); // Safe to call
+   * }
+   */
   isFail(): boolean
+  /**
+   * Converts this Result's Ok value to a Maybe.
+   * 
+   * This method transforms a Result into a Maybe, focusing on the success path:
+   * - If this Result is an Ok variant, returns a Some Maybe containing the value
+   * - If this Result is a Fail variant, returns a None Maybe
+   * 
+   * This is useful when you want to continue with Maybe operations and no longer
+   * need to track the specific error type.
+   * 
+   * @returns A Maybe containing the Ok value if present, or None
+   * 
+   * @example
+   * // Converting from Result to Maybe
+   * const userResult: Result<User, ApiError> = fetchUser(userId);
+   * 
+   * // Focus only on the success case by converting to Maybe
+   * const userMaybe: Maybe<User> = userResult.maybeOk();
+   * 
+   * // Continue with Maybe operations
+   * const userName = userMaybe
+   *   .map(user => user.name)
+   *   .valueOr("Unknown User");
+   */
   maybeOk(): IMaybe<NonNullable<T>>
+  /**
+   * Converts this Result's Fail value to a Maybe.
+   * 
+   * This method transforms a Result into a Maybe, focusing on the failure path:
+   * - If this Result is a Fail variant, returns a Some Maybe containing the error
+   * - If this Result is an Ok variant, returns a None Maybe
+   * 
+   * This is useful when you want to specifically work with errors when they occur,
+   * but don't care about the success value.
+   * 
+   * @returns A Maybe containing the Fail value if present, or None
+   * 
+   * @example
+   * // Collecting errors across multiple operations
+   * const results: Array<Result<any, Error>> = runValidations();
+   * 
+   * const errors = results
+   *   .map(result => result.maybeFail())
+   *   .filter(maybeErr => maybeErr.isSome())
+   *   .map(maybeErr => maybeErr.valueOrThrow());
+   * 
+   * if (errors.length > 0) {
+   *   displayErrors(errors);
+   * }
+   */
   maybeFail(): IMaybe<E>
+  /**
+   * Extracts the Ok value from this Result.
+   * 
+   * This method should only be called when you're certain that the Result is an Ok variant.
+   * If the Result is a Fail variant, this method will throw an exception.
+   * 
+   * @returns The contained Ok value
+   * @throws Error if the Result is a Fail variant
+   * 
+   * @example
+   * // Safe usage with type guard
+   * const result = parseJson<Config>(jsonString);
+   * 
+   * if (result.isOk()) {
+   *   const config = result.unwrap();
+   *   initializeApp(config);
+   * }
+   * 
+   * // Alternative safe usage with pattern matching
+   * result.match({
+   *   ok: config => initializeApp(config),
+   *   fail: error => showError(error)
+   * });
+   * 
+   * // Unsafe usage (might throw)
+   * const config = result.unwrap(); // Throws if result is Fail
+   */
+  /**
+   * Extracts the Ok value from this Result.
+   * 
+   * This method should only be called when you're certain that the Result is an Ok variant.
+   * If the Result is a Fail variant, this method will throw an exception.
+   * 
+   * @returns The contained Ok value
+   * @throws Error if the Result is a Fail variant
+   * 
+   * @example
+   * // Safe usage with type guard
+   * const result = parseJson<Config>(jsonString);
+   * 
+   * if (result.isOk()) {
+   *   const config = result.unwrap();
+   *   initializeApp(config);
+   * }
+   * 
+   * // Alternative safe usage with pattern matching
+   * result.match({
+   *   ok: config => initializeApp(config),
+   *   fail: error => showError(error)
+   * });
+   * 
+   * // Unsafe usage (might throw)
+   * const config = result.unwrap(); // Throws if result is Fail
+   */
   unwrap(): T | never
+
+  /**
+   * Extracts the Ok value from this Result or returns a default value.
+   * 
+   * This method provides a safe way to unwrap a Result without risking exceptions.
+   * If the Result is an Ok variant, the contained value is returned.
+   * If the Result is a Fail variant, the provided default value is returned.
+   * 
+   * @param opt The default value to return if this Result is a Fail variant
+   * @returns The contained Ok value or the provided default
+   * 
+   * @example
+   * // Using unwrapOr for default values
+   * const userResult = getUserById(userId);
+   * 
+   * // If user not found, use a guest user
+   * const user = userResult.unwrapOr({
+   *   id: 0,
+   *   name: "Guest",
+   *   role: "visitor"
+   * });
+   * 
+   * // Using unwrapOr in a chain
+   * const userName = getUserById(userId)
+   *   .map(user => user.name)
+   *   .unwrapOr("Unknown User");
+   */
   unwrapOr(opt: T): T
+
+  /**
+   * Extracts the Fail value from this Result.
+   * 
+   * This method should only be called when you're certain that the Result is a Fail variant.
+   * If the Result is an Ok variant, this method will throw an exception.
+   * 
+   * @returns The contained Fail value
+   * @throws ReferenceError if the Result is an Ok variant
+   * 
+   * @example
+   * // Safe usage with type guard
+   * const result = validateInput(formData);
+   * 
+   * if (result.isFail()) {
+   *   const validationErrors = result.unwrapFail();
+   *   displayErrors(validationErrors);
+   * }
+   * 
+   * // Alternative safe usage with pattern matching
+   * result.match({
+   *   ok: data => submitForm(data),
+   *   fail: errors => displayErrors(errors)
+   * });
+   */
   unwrapFail(): E | never
+  /**
+   * Applies a pattern matching object to this Result.
+   * 
+   * This method provides a functional way to handle both Ok and Fail variants
+   * in a single expression, enforcing exhaustive handling of all cases.
+   * 
+   * @typeParam M - The return type of the pattern matching functions
+   * @param fn - An object containing functions to handle each variant:
+   *   - `ok`: Function that processes the Ok value
+   *   - `fail`: Function that processes the Fail value
+   * @returns The result of applying the matching function to the contained value
+   * 
+   * @example
+   * // Basic pattern matching with different return types
+   * const result = fetchData();
+   * 
+   * const message = result.match({
+   *   ok: data => `Successfully loaded ${data.items.length} items`,
+   *   fail: error => `Error: ${error.message}`
+   * });
+   * 
+   * // Pattern matching for control flow
+   * result.match({
+   *   ok: data => {
+   *     renderData(data);
+   *     updateLastFetchTime();
+   *   },
+   *   fail: error => {
+   *     logError(error);
+   *     showRetryButton();
+   *   }
+   * });
+   * 
+   * // Pattern matching with transformations
+   * const apiResponse = makeApiCall()
+   *   .match({
+   *     ok: successResponse => ({ 
+   *       status: 'success', 
+   *       data: successResponse 
+   *     }),
+   *     fail: errorResponse => ({
+   *       status: 'error',
+   *       message: errorResponse.message,
+   *       code: errorResponse.code
+   *     })
+   *   });
+   */
   match<M>(fn: IResultMatchPattern<T, E, M>): M
+
+  /**
+   * Maps the Ok value of this Result using the provided function.
+   * 
+   * If this Result is an Ok variant, this method transforms the contained value using
+   * the provided function and returns a new Ok Result with the transformed value.
+   * If this Result is a Fail variant, it returns a new Fail Result with the same error.
+   * 
+   * This operation is similar to Array.map but for a Result's Ok value.
+   * 
+   * @typeParam M - The type of the mapped value
+   * @param fn - A function that transforms the Ok value
+   * @returns A new Result with the transformed value if Ok, or the original error if Fail
+   * 
+   * @example
+   * // Transforming user data
+   * const userResult = fetchUser(userId);
+   * 
+   * const userProfileResult = userResult.map(user => ({
+   *   name: user.name,
+   *   email: user.email,
+   *   avatar: user.avatarUrl || 'default-avatar.png'
+   * }));
+   * 
+   * // Chaining multiple transformations
+   * const userNameResult = fetchUser(userId)
+   *   .map(user => user.profile)
+   *   .map(profile => profile.name)
+   *   .map(name => name.toUpperCase());
+   * 
+   * // Error case is automatically propagated
+   * const result = validate("invalid-input") // Returns Fail
+   *   .map(value => process(value))          // Map is not applied
+   *   .map(result => format(result));        // Map is not applied
+   * 
+   * // result is still the original Fail value
+   */
   map<M>(fn: (val: T) => M): IResult<M, E>
+
+  /**
+   * Maps the Fail value of this Result using the provided function.
+   * 
+   * If this Result is a Fail variant, this method transforms the error using
+   * the provided function and returns a new Fail Result with the transformed error.
+   * If this Result is an Ok variant, it returns a new Ok Result with the same value.
+   * 
+   * This is useful for transforming errors while preserving their failure state.
+   * 
+   * @typeParam M - The type of the mapped error
+   * @param fn - A function that transforms the Fail value
+   * @returns A new Result with the transformed error if Fail, or the original value if Ok
+   * 
+   * @example
+   * // Enriching error information
+   * const result = fetchData()
+   *   .mapFail(error => ({
+   *     ...error,
+   *     timestamp: new Date(),
+   *     context: 'fetchData'
+   *   }));
+   * 
+   * // Converting between error types
+   * const standardizedResult = externalApiCall()
+   *   .mapFail(apiError => new AppError({
+   *     code: mapErrorCode(apiError.code),
+   *     message: apiError.message,
+   *     source: 'ExternalAPI'
+   *   }));
+   * 
+   * // Localizing error messages
+   * const localizedResult = validateInput(form)
+   *   .mapFail(errors => errors.map(err => ({
+   *     ...err,
+   *     message: translateErrorMessage(err.message, currentLocale)
+   *   })));
+   */
   mapFail<M>(fn: (err: E) => M): IResult<T, M>
+
+  /**
+   * Chains a function that returns another Result.
+   * 
+   * If this Result is an Ok variant, this method applies the function to the contained value,
+   * which returns a new Result. This allows for sequencing operations that might fail.
+   * If this Result is a Fail variant, it returns a new Fail Result with the same error without
+   * calling the function.
+   * 
+   * This operation is similar to flatMap/bind in other functional programming contexts.
+   * 
+   * @typeParam M - The type of the value in the returned Result
+   * @param fn - A function that takes the Ok value and returns a new Result
+   * @returns The Result returned by fn if this Result is Ok, or a Fail Result with the original error
+   * 
+   * @example
+   * // Sequential operations that might fail
+   * const result = parseConfigFile(filePath)
+   *   .flatMap(config => validateConfig(config))
+   *   .flatMap(validConfig => initializeSystem(validConfig));
+   * 
+   * // Database transaction example
+   * const transactionResult = connectToDatabase()
+   *   .flatMap(connection => beginTransaction(connection))
+   *   .flatMap(transaction => executeQueries(transaction))
+   *   .flatMap(transaction => commitTransaction(transaction));
+   * 
+   * // Early return on failure
+   * const userResult = authenticateUser(credentials) // Might return Fail
+   *   .flatMap(user => authorizeUser(user, resource)) // Only called if authentication succeeds
+   *   .flatMap(user => loadUserProfile(user));        // Only called if authorization succeeds
+   */
   flatMap<M>(fn: (val: T) => IResult<M, E>): IResult<M, E>
   
   /**
@@ -105,45 +455,308 @@ export interface IResult<T, E> {
   flatMapMaybe<M>(fn: (val: T) => IMaybe<M>, err: E): IResult<M, E>
 
   /**
-   * Execute functions with side-effects.
+   * Executes side-effect functions based on the Result variant without changing the Result.
+   * 
+   * This method allows you to perform actions that don't affect the Result's value:
+   * - If this Result is an Ok variant, it calls the provided `ok` function with the contained value
+   * - If this Result is a Fail variant, it calls the provided `fail` function with the error
+   * 
+   * Both functions are optional; if not provided, nothing happens for that variant.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   * 
+   * @example
+   * // Logging based on Result variant
+   * fetchData().tap({
+   *   ok: data => console.log("Data fetched successfully:", data),
+   *   fail: error => console.error("Failed to fetch data:", error)
+   * });
+   * 
+   * // Metrics and analytics
+   * processPayment(paymentInfo).tap({
+   *   ok: result => {
+   *     analytics.trackEvent("payment_success", { 
+   *       amount: result.amount,
+   *       method: result.method
+   *     });
+   *   },
+   *   fail: error => {
+   *     analytics.trackEvent("payment_failure", { 
+   *       error: error.code,
+   *       message: error.message
+   *     });
+   *   }
+   * });
+   * 
+   * // Partial application (only handling one variant)
+   * validateInput(formData).tap({
+   *   fail: errors => highlightFormErrors(errors)
+   * });
    */
   tap(val: Partial<IResultMatchPattern<T, E, void>>): void
 
   /**
-   * Execute a function with side-effects when maybe is a Fail.
+   * Executes a side-effect function when this Result is a Fail variant.
+   * 
+   * This method is a specialized version of `tap` that only handles the Fail case:
+   * - If this Result is a Fail variant, it calls the provided function with the error
+   * - If this Result is an Ok variant, it does nothing
+   * 
+   * @param f - A function to execute with the Fail value
+   * 
+   * @example
+   * // Error logging
+   * processRequest(req).tapFail(error => {
+   *   logger.error("Request processing failed", {
+   *     error: error.message,
+   *     stack: error.stack,
+   *     requestId: req.id
+   *   });
+   * });
+   * 
+   * // UI error handling
+   * submitForm(formData).tapFail(errors => {
+   *   displayErrors(errors);
+   *   highlightInvalidFields(errors);
+   *   scrollToFirstError();
+   * });
+   * 
+   * // Monitoring and alerting
+   * criticalOperation().tapFail(error => {
+   *   if (error.severity === 'high') {
+   *     alertOps(error);
+   *     incrementFailureCounter();
+   *   }
+   * });
    */
   tapFail(f: (val: E) => void): void
 
   /**
-   * Execute a function with side-effects when maybe is an Ok.
+   * Executes a side-effect function when this Result is an Ok variant.
+   * 
+   * This method is a specialized version of `tap` that only handles the Ok case:
+   * - If this Result is an Ok variant, it calls the provided function with the contained value
+   * - If this Result is a Fail variant, it does nothing
+   * 
+   * @param f - A function to execute with the Ok value
+   * 
+   * @example
+   * // Logging successful operations
+   * saveUser(userData).tapOk(user => {
+   *   console.log(`User ${user.id} saved successfully`);
+   *   updateLastSavedTimestamp();
+   * });
+   * 
+   * // UI updates on success
+   * fetchData().tapOk(data => {
+   *   updateUI(data);
+   *   hideLoadingIndicator();
+   * });
+   * 
+   * // Analytics for successful operations
+   * checkout(cart).tapOk(order => {
+   *   analytics.trackPurchase({
+   *     orderId: order.id,
+   *     amount: order.total,
+   *     items: order.items.length
+   *   });
+   * });
    */
   tapOk(f: (val: T) => void): void
 
   /**
-   * Convert Ok result into Fail using projected value from Ok
+   * Converts an Ok Result into a Fail Result using a transformation function.
+   * 
+   * This method inverts the Result's state by:
+   * - If this Result is an Ok variant, it applies the function to the contained value
+   *   to generate an error and returns a Fail Result with that error
+   * - If this Result is a Fail variant, it returns the original Fail Result unchanged
+   * 
+   * This is useful for scenarios where success conditions need to be converted to failures
+   * based on the content of the success value.
+   * 
+   * @param fn - A function that transforms the Ok value into a Fail value
+   * @returns A Fail Result with the generated error, or the original Fail Result
+   * 
+   * @example
+   * // Implementing validation logic
+   * const userResult = getUserById(userId);
+   * 
+   * const validatedUser = userResult.toFailWhenOk(user => {
+   *   if (!user.isActive) return new Error("User account is inactive");
+   *   if (user.accessLevel < requiredLevel) return new Error("Insufficient access level");
+   *   return null; // This case won't happen due to TypeScript's return type checking
+   * });
+   * 
+   * // Implementing business rule validation
+   * const orderResult = createOrder(orderData);
+   * 
+   * const validatedOrder = orderResult.toFailWhenOk(order => {
+   *   if (order.items.length === 0) return new ValidationError("Order must contain at least one item");
+   *   if (order.total < minimumOrderAmount) return new ValidationError(`Order total must be at least ${minimumOrderAmount}`);
+   *   return new ValidationError(""); // TypeScript requires a return, but this won't be reached in valid code
+   * });
    */
   toFailWhenOk(fn: (val: T) => E): IResult<T, E>
 
   /**
-   * Convert Ok result into Fail using a provided value
+   * Converts an Ok Result into a Fail Result using a provided error value.
+   * 
+   * This method inverts the Result's state by:
+   * - If this Result is an Ok variant, it returns a Fail Result with the provided error
+   * - If this Result is a Fail variant, it returns a Fail Result with the provided error,
+   *   replacing the original error
+   * 
+   * This is useful for scenarios where you want to override or standardize error values.
+   * 
+   * @param val - The error value to use in the returned Fail Result
+   * @returns A Fail Result containing the provided error
+   * 
+   * @example
+   * // Standardizing error messages
+   * const result = parseInput(rawInput)
+   *   .toFailWhenOkFrom(new Error("Input validation failed"));
+   * 
+   * // Conditional error replacement
+   * let result = processData(data);
+   * 
+   * if (shouldUseStandardError) {
+   *   result = result.toFailWhenOkFrom(standardError);
+   * }
+   * 
+   * // Overriding authentication errors with a generic message
+   * const authResult = authenticate(credentials)
+   *   .toFailWhenOkFrom(new Error("Authentication failed"));
    */
   toFailWhenOkFrom(val: E): IResult<T, E>
 
   /**
-   * Execute a function with side-effects.
-   * Returns this to continue operations
+   * Executes side-effect functions and returns the original Result for chaining.
+   * 
+   * This method is similar to `tap`, but returns the Result itself to allow for
+   * further method chaining:
+   * - If this Result is an Ok variant, it calls the provided `ok` function with the contained value
+   * - If this Result is a Fail variant, it calls the provided `fail` function with the error
+   * 
+   * Both functions are optional; if not provided, nothing happens for that variant.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   * @returns This Result, unchanged
+   * 
+   * @example
+   * // Chaining operations with logging
+   * return fetchUser(userId)
+   *   .tapThru({
+   *     ok: user => console.log(`User ${user.id} fetched`),
+   *     fail: err => console.error(`Failed to fetch user: ${err.message}`)
+   *   })
+   *   .map(user => transformUser(user))
+   *   .tapThru({
+   *     ok: profile => console.log(`User profile created`)
+   *   });
+   * 
+   * // Progressive UI updates in a chain
+   * processForm(data)
+   *   .tapThru({
+   *     ok: () => updateProgressBar(0.33)
+   *   })
+   *   .flatMap(validated => saveToDatabase(validated))
+   *   .tapThru({
+   *     ok: () => updateProgressBar(0.66),
+   *     fail: err => showErrorNotification(err)
+   *   })
+   *   .flatMap(saved => notifyUser(saved))
+   *   .tapThru({
+   *     ok: () => updateProgressBar(1.0),
+   *     fail: err => showErrorNotification(err)
+   *   });
    */
   tapThru(val: Partial<IResultMatchPattern<T, E, void>>): IResult<T, E>
 
   /**
-   * Execute a function with side-effects when maybe is a OK.
-   * Returns this to continue operations
+   * Executes a side-effect function when this Result is an Ok variant and returns the original
+   * Result for chaining.
+   * 
+   * This method is a specialized version of `tapThru` that only handles the Ok case:
+   * - If this Result is an Ok variant, it calls the provided function with the contained value
+   * - If this Result is a Fail variant, it does nothing
+   * 
+   * In both cases, it returns the original Result unchanged.
+   * 
+   * @param fn - A function to execute with the Ok value
+   * @returns This Result, unchanged
+   * 
+   * @example
+   * // Chaining with logging for successful operations
+   * return getUserById(userId)
+   *   .tapOkThru(user => console.log(`Found user: ${user.name}`))
+   *   .map(user => user.profile)
+   *   .tapOkThru(profile => console.log(`Profile accessed`))
+   *   .flatMap(profile => getProfileSettings(profile.id));
+   * 
+   * // Progressive UI updates on success
+   * submitOrder(order)
+   *   .tapOkThru(() => {
+   *     showMessage("Order submitted");
+   *     updateProgressStep(1);
+   *   })
+   *   .flatMap(order => processPayment(order))
+   *   .tapOkThru(() => {
+   *     showMessage("Payment processed");
+   *     updateProgressStep(2);
+   *   })
+   *   .flatMap(order => finalizeOrder(order));
    */
   tapOkThru(fn: (val: T) => void): IResult<T, E>
 
   /**
-   * Execute a function with side-effects when maybe is a Fail.
-   * Returns this to continue operations
+   * Executes a side-effect function when this Result is a Fail variant and returns the original
+   * Result for chaining.
+   * 
+   * This method is a specialized version of `tapThru` that only handles the Fail case:
+   * - If this Result is a Fail variant, it calls the provided function with the error
+   * - If this Result is an Ok variant, it does nothing
+   * 
+   * In both cases, it returns the original Result unchanged.
+   * 
+   * @param fn - A function to execute with the Fail value
+   * @returns This Result, unchanged
+   * 
+   * @example
+   * // Chaining with error logging
+   * return validateInput(input)
+   *   .tapFailThru(errors => logValidationErrors(errors))
+   *   .flatMap(input => processInput(input))
+   *   .tapFailThru(error => logProcessingError(error))
+   *   .flatMap(result => saveResult(result));
+   * 
+   * // Progressive error handling
+   * authenticateUser(credentials)
+   *   .tapFailThru(error => {
+   *     logAuthFailure(error);
+   *     updateLoginAttempts();
+   *   })
+   *   .flatMap(user => authorizeUser(user, resource))
+   *   .tapFailThru(error => {
+   *     logAuthorizationFailure(error);
+   *     recordAccessAttempt(resource);
+   *   });
+   * 
+   * // Analytics tracking in a chain
+   * checkout(cart)
+   *   .tapFailThru(error => {
+   *     analytics.trackEvent("checkout_failure", {
+   *       error: error.code,
+   *       step: "initial_validation"
+   *     });
+   *   })
+   *   .flatMap(validCart => processPayment(validCart))
+   *   .tapFailThru(error => {
+   *     analytics.trackEvent("checkout_failure", {
+   *       error: error.code,
+   *       step: "payment_processing"
+   *     });
+   *   });
    */
   tapFailThru(fn: (val: E) => void): IResult<T, E>
 }

--- a/src/result/result.interface.ts
+++ b/src/result/result.interface.ts
@@ -19,6 +19,90 @@ export interface IResult<T, E> {
   map<M>(fn: (val: T) => M): IResult<M, E>
   mapFail<M>(fn: (err: E) => M): IResult<T, M>
   flatMap<M>(fn: (val: T) => IResult<M, E>): IResult<M, E>
+  
+  /**
+   * Maps the success value of this Result to a Maybe, and then flattens the resulting structure.
+   * 
+   * This method is particularly useful when working with optional properties or values that might be undefined/null.
+   * It allows for seamless chaining of Result and Maybe monads without explicit unwrapping and re-wrapping.
+   * 
+   * @typeParam M - The type of the value contained in the returned Result if successful
+   * @param fn - A function that takes the success value of this Result and returns a Maybe
+   * @param err - The error value to use if the Maybe is None
+   * @returns 
+   *   - If this Result is a Fail: A Fail Result containing the original error
+   *   - If this Result is an Ok and fn returns Some: An Ok Result containing the unwrapped value
+   *   - If this Result is an Ok but fn returns None: A Fail Result containing the provided err
+   * 
+   * @example
+   * // Type definitions
+   * interface User {
+   *   id: number;
+   *   profile?: {
+   *     name: string;
+   *     email: string;
+   *   };
+   * }
+   * 
+   * // Success path with Some
+   * const getUser = (): Result<User, Error> => 
+   *   ok({ id: 1, profile: { name: "Alice", email: "alice@example.com" } });
+   * 
+   * // Chain to access a potentially undefined property safely
+   * const getName = getUser()
+   *   .flatMapMaybe(
+   *     user => maybe(user.profile),
+   *     new Error("Profile not found")
+   *   )
+   *   .map(profile => profile.name);
+   * 
+   * // getName is Result<string, Error> containing "Alice"
+   * 
+   * // Handling None case
+   * const getUserWithoutProfile = (): Result<User, Error> => 
+   *   ok({ id: 2 }); // No profile property
+   * 
+   * const getName2 = getUserWithoutProfile()
+   *   .flatMapMaybe(
+   *     user => maybe(user.profile),
+   *     new Error("Profile not found")
+   *   )
+   *   .map(profile => profile.name);
+   * 
+   * // getName2 is Result<string, Error> containing Error("Profile not found")
+   * 
+   * // Using with nullish values
+   * type Response = { data?: { value: number } | null };
+   * 
+   * const response: Response = { data: null };
+   * const value = ok<Response, string>(response)
+   *   .flatMapMaybe(
+   *     res => maybe(res.data),
+   *     "No data available"
+   *   )
+   *   .flatMapMaybe(
+   *     data => maybe(data.value),
+   *     "Value not present"
+   *   );
+   * 
+   * // value is Result<number, string> containing "No data available"
+   * 
+   * // Working with arrays and optional chaining
+   * interface Post { comments?: Array<{ id: number, text: string }> }
+   * 
+   * const getFirstComment = (post: Post): Result<string, string> =>
+   *   ok(post)
+   *     .flatMapMaybe(
+   *       p => maybe(p.comments),
+   *       "No comments found"
+   *     )
+   *     .flatMapMaybe(
+   *       comments => maybe(comments[0]),
+   *       "Comment list is empty"
+   *     )
+   *     .map(comment => comment.text);
+   */
+  flatMapMaybe<M>(fn: (val: T) => IMaybe<M>, err: E): IResult<M, E>
 
   /**
    * Execute functions with side-effects.
@@ -71,6 +155,55 @@ export interface IResultOk<T, E = never> extends IResult<T, E> {
   match<M>(fn: IResultMatchPattern<T, never, M>): M
   map<M>(fn: (val: T) => M): IResultOk<M, never>
   mapFail<M>(fn: (err: E) => M): IResultOk<T, never>
+  
+  /**
+   * Specialized version of flatMapMaybe for Ok Results.
+   * 
+   * This method always applies the provided function to the contained value and
+   * returns either an Ok result with the unwrapped Some value or a Fail result with
+   * the provided error if the Maybe is None.
+   * 
+   * @typeParam M - The type of the value contained in the returned Result if successful
+   * @param fn - A function that takes the success value of this Result and returns a Maybe
+   * @param err - The error value to use if the Maybe is None
+   * @returns Either a Result<M, E> containing the unwrapped value or a failure containing the provided error
+   * 
+   * @example
+   * // Using flatMapMaybe with a chain of optional properties
+   * interface Config {
+   *   settings?: {
+   *     database?: {
+   *       url?: string
+   *     }
+   *   }
+   * }
+   * 
+   * // Traditional approach with null checks
+   * function getDatabaseUrl(config: Config): Result<string, string> {
+   *   if (!config.settings) return fail("No settings found");
+   *   if (!config.settings.database) return fail("No database settings found");
+   *   if (!config.settings.database.url) return fail("No database URL found");
+   *   return ok(config.settings.database.url);
+   * }
+   * 
+   * // Using flatMapMaybe
+   * function getDatabaseUrlMonadic(config: Config): Result<string, string> {
+   *   return ok(config)
+   *     .flatMapMaybe(
+   *       c => maybe(c.settings),
+   *       "No settings found"
+   *     )
+   *     .flatMapMaybe(
+   *       settings => maybe(settings.database),
+   *       "No database settings found"
+   *     )
+   *     .flatMapMaybe(
+   *       database => maybe(database.url),
+   *       "No database URL found"
+   *     );
+   * }
+   */
+  flatMapMaybe<M>(fn: (val: T) => IMaybe<M>, err: E): IResult<M, E>
 }
 
 export interface IResultFail<T, E> extends IResult<T, E> {
@@ -81,4 +214,42 @@ export interface IResultFail<T, E> extends IResult<T, E> {
   map<M>(fn: (val: T) => M): IResultFail<never, E>
   mapFail<M>(fn: (err: E) => M): IResultFail<never, M>
   flatMap<M>(fn: (val: T) => IResult<M, E>): IResultFail<never, E>
+  /**
+   * Specialized version of flatMapMaybe for Fail Results.
+   * 
+   * This method short-circuits the operation and always returns a Fail result
+   * containing the original error, without executing the provided function.
+   * This maintains the monadic law that operations on Fail do not execute the transformation.
+   * 
+   * @typeParam M - The type parameter for the potential success value (never used in this case)
+   * @returns A Fail Result containing the original error
+   * 
+   * @example
+   * // Error short-circuiting in a chain of operations
+   * const result = fail<User, string>("User not found")
+   *   .flatMapMaybe(
+   *     user => maybe(user.profile), // This function is never called
+   *     "Profile not found"          // This error is never used
+   *   )
+   *   .flatMapMaybe(
+   *     profile => maybe(profile.email), // This function is never called
+   *     "Email not found"                // This error is never used
+   *   );
+   * 
+   * // result is Result<string, string> containing "User not found" (the original error)
+   * 
+   * // Type safety with never
+   * type ApiError = { code: number, message: string };
+   * 
+   * const apiResult = fail<never, ApiError>({ code: 404, message: "Not found" })
+   *   .flatMapMaybe(
+   *     // TypeScript ensures we can't access properties on 'never'
+   *     // The parameter is essentially inaccessible
+   *     _ => maybe(null as never),
+   *     { code: 500, message: "Server error" }
+   *   );
+   * 
+   * // apiResult is Result<never, ApiError> containing { code: 404, message: "Not found" }
+   */
+  flatMapMaybe(): IResultFail<never, E>
 }

--- a/src/result/result.spec.ts
+++ b/src/result/result.spec.ts
@@ -389,7 +389,6 @@ describe('result', () => {
     it('should return Fail with error when Result is Ok but Maybe is None', () => {
       const okResult = ok<number, string>(5)
       const res = okResult.flatMapMaybe(() => none<number>(), 'No value found')
-
       expect(res.isFail()).toEqual(true)
       expect(res.unwrapFail()).toEqual('No value found')
     })

--- a/src/result/result.spec.ts
+++ b/src/result/result.spec.ts
@@ -1,4 +1,5 @@
 import { ok, fail, result } from './result.factory'
+import { IMaybe, maybe, none, some } from '../maybe/public_api'
 
 describe('result', () => {
   describe('ok', () => {
@@ -373,6 +374,73 @@ describe('result', () => {
       expect(sideEffect).toEqual('failed in here')
 
       done()
+    })
+  })
+
+  describe('flatMapMaybe', () => {
+    it('should return Ok with value when Result is Ok and Maybe is Some', () => {
+      const okResult = ok<number, string>(5)
+      const res = okResult.flatMapMaybe((val) => maybe(val * 2), 'No value found')
+
+      expect(res.isOk()).toEqual(true)
+      expect(res.unwrap()).toEqual(10)
+    })
+
+    it('should return Fail with error when Result is Ok but Maybe is None', () => {
+      const okResult = ok<number, string>(5)
+      const res = okResult.flatMapMaybe(() => none<number>(), 'No value found')
+
+      expect(res.isFail()).toEqual(true)
+      expect(res.unwrapFail()).toEqual('No value found')
+    })
+
+    it('should return Fail with original error when Result is Fail', () => {
+      const failResult = fail<number, string>('Original error')
+      const res = failResult.flatMapMaybe((val: number) => maybe(val * 2), 'No value found')
+
+      expect(res.isFail()).toEqual(true)
+      expect(res.unwrapFail()).toEqual('Original error')
+    })
+
+    it('should ', () => {
+      const okResult = ok<{ result: number; data: IMaybe<{ zeta: number }> }, Error>({ result: 1, data: some({ zeta: 2 }) })
+      const res = okResult.flatMapMaybe((a) => a.data, new Error('No value found'))
+
+      expect(res.isFail()).toEqual(false)
+      expect(res.unwrap()).toEqual({ zeta: 2 })
+    })
+
+    it('should work with complex object properties', () => {
+      type User = {
+        id: number
+        profile?: {
+          name: string
+        }
+      }
+
+      // User with profile
+      const userWithProfile: User = { id: 1, profile: { name: 'John' } }
+      const okResult = ok<User, string>(userWithProfile)
+
+      const res1 = okResult.flatMapMaybe(
+        (user: User) => maybe(user.profile),
+        'Profile not found'
+      )
+
+      expect(res1.isOk()).toEqual(true)
+      expect(res1.unwrap().name).toEqual('John')
+
+      // User without profile
+      const userWithoutProfile: User = { id: 2 }
+      const okResult2 = ok<User, string>(userWithoutProfile)
+
+      const res2 = okResult2.flatMapMaybe(
+        (user: User) => maybe(user.profile),
+        'Profile not found'
+      )
+
+      expect(res2.isFail()).toEqual(true)
+      expect(res2.unwrapFail()).toEqual('Profile not found')
     })
   })
 })

--- a/src/result/result.ts
+++ b/src/result/result.ts
@@ -10,25 +10,717 @@ export abstract class Result<TOk, TFail> implements IResult<TOk, TFail> {
     return new FailResult<TOk, TFail>(value)
   }
 
+  /**
+   * Type guard that determines if this Result is an Ok variant.
+   * 
+   * This method acts as a TypeScript type guard, narrowing the type of the Result
+   * to OkResult when it returns true, which helps with type safety in conditional blocks.
+   * 
+   * @returns true if this Result is an Ok variant, false otherwise
+   * 
+   * @example
+   * const result = getUser(userId);
+   * 
+   * if (result.isOk()) {
+   *   // TypeScript knows that result is OkResult<User, Error> here
+   *   const user = result.unwrap(); // Safe to call
+   *   console.log(user.name);
+   * } else {
+   *   // TypeScript knows that result is FailResult<User, Error> here
+   *   const error = result.unwrapFail(); // Safe to call
+   *   console.error(error.message);
+   * }
+   */
   abstract isOk(): this is OkResult<TOk, TFail>
+
+  /**
+   * Type guard that determines if this Result is a Fail variant.
+   * 
+   * This method acts as a TypeScript type guard, narrowing the type of the Result
+   * to FailResult when it returns true, which helps with type safety in conditional blocks.
+   * 
+   * @returns true if this Result is a Fail variant, false otherwise
+   * 
+   * @example
+   * const result = authenticate(credentials);
+   * 
+   * if (result.isFail()) {
+   *   // TypeScript knows that result is FailResult<Session, AuthError> here
+   *   const error = result.unwrapFail(); // Safe to call
+   *   handleAuthError(error);
+   * } else {
+   *   // TypeScript knows that result is OkResult<Session, AuthError> here
+   *   startSession(result.unwrap()); // Safe to call
+   * }
+   */
   abstract isFail(): this is FailResult<TOk, TFail>
+
+  /**
+   * Extracts the Ok value from this Result.
+   * 
+   * This method should only be called when you're certain that the Result is an Ok variant.
+   * If the Result is a Fail variant, this method will throw an exception.
+   * 
+   * @returns The contained Ok value
+   * @throws Error if the Result is a Fail variant
+   * 
+   * @example
+   * // Safe usage with type guard
+   * const result = parseJson<Config>(jsonString);
+   * 
+   * if (result.isOk()) {
+   *   const config = result.unwrap();
+   *   initializeApp(config);
+   * }
+   * 
+   * // Alternative safe usage with pattern matching
+   * result.match({
+   *   ok: config => initializeApp(config),
+   *   fail: error => showError(error)
+   * });
+   * 
+   * // Unsafe usage (might throw)
+   * const config = result.unwrap(); // Throws if result is Fail
+   */
   abstract unwrap(): TOk | never
+
+  /**
+   * Extracts the Ok value from this Result or returns a default value.
+   * 
+   * This method provides a safe way to unwrap a Result without risking exceptions.
+   * If the Result is an Ok variant, the contained value is returned.
+   * If the Result is a Fail variant, the provided default value is returned.
+   * 
+   * @param opt The default value to return if this Result is a Fail variant
+   * @returns The contained Ok value or the provided default
+   * 
+   * @example
+   * // Using unwrapOr for default values
+   * const userResult = getUserById(userId);
+   * 
+   * // If user not found, use a guest user
+   * const user = userResult.unwrapOr({
+   *   id: 0,
+   *   name: "Guest",
+   *   role: "visitor"
+   * });
+   * 
+   * // Using unwrapOr in a chain
+   * const userName = getUserById(userId)
+   *   .map(user => user.name)
+   *   .unwrapOr("Unknown User");
+   */
   abstract unwrapOr(opt: TOk): TOk
+
+  /**
+   * Extracts the Fail value from this Result.
+   * 
+   * This method should only be called when you're certain that the Result is a Fail variant.
+   * If the Result is an Ok variant, this method will throw an exception.
+   * 
+   * @returns The contained Fail value
+   * @throws ReferenceError if the Result is an Ok variant
+   * 
+   * @example
+   * // Safe usage with type guard
+   * const result = validateInput(formData);
+   * 
+   * if (result.isFail()) {
+   *   const validationErrors = result.unwrapFail();
+   *   displayErrors(validationErrors);
+   * }
+   * 
+   * // Alternative safe usage with pattern matching
+   * result.match({
+   *   ok: data => submitForm(data),
+   *   fail: errors => displayErrors(errors)
+   * });
+   */
   abstract unwrapFail(): TFail | never
+
+  /**
+   * Converts this Result's Ok value to a Maybe.
+   * 
+   * This method transforms a Result into a Maybe, focusing on the success path:
+   * - If this Result is an Ok variant, returns a Some Maybe containing the value
+   * - If this Result is a Fail variant, returns a None Maybe
+   * 
+   * This is useful when you want to continue with Maybe operations and no longer
+   * need to track the specific error type.
+   * 
+   * @returns A Maybe containing the Ok value if present, or None
+   * 
+   * @example
+   * // Converting from Result to Maybe
+   * const userResult: Result<User, ApiError> = fetchUser(userId);
+   * 
+   * // Focus only on the success case by converting to Maybe
+   * const userMaybe: Maybe<User> = userResult.maybeOk();
+   * 
+   * // Continue with Maybe operations
+   * const userName = userMaybe
+   *   .map(user => user.name)
+   *   .valueOr("Unknown User");
+   */
   abstract maybeOk(): IMaybe<NonNullable<TOk>>
+
+  /**
+   * Converts this Result's Fail value to a Maybe.
+   * 
+   * This method transforms a Result into a Maybe, focusing on the failure path:
+   * - If this Result is a Fail variant, returns a Some Maybe containing the error
+   * - If this Result is an Ok variant, returns a None Maybe
+   * 
+   * This is useful when you want to specifically work with errors when they occur,
+   * but don't care about the success value.
+   * 
+   * @returns A Maybe containing the Fail value if present, or None
+   * 
+   * @example
+   * // Collecting errors across multiple operations
+   * const results: Array<Result<any, Error>> = runValidations();
+   * 
+   * const errors = results
+   *   .map(result => result.maybeFail())
+   *   .filter(maybeErr => maybeErr.isSome())
+   *   .map(maybeErr => maybeErr.valueOrThrow());
+   * 
+   * if (errors.length > 0) {
+   *   displayErrors(errors);
+   * }
+   */
   abstract maybeFail(): IMaybe<TFail>
+
+  /**
+   * Applies a pattern matching object to this Result.
+   * 
+   * This method provides a functional way to handle both Ok and Fail variants
+   * in a single expression, enforcing exhaustive handling of all cases.
+   * 
+   * @typeParam M - The return type of the pattern matching functions
+   * @param fn - An object containing functions to handle each variant:
+   *   - `ok`: Function that processes the Ok value
+   *   - `fail`: Function that processes the Fail value
+   * @returns The result of applying the matching function to the contained value
+   * 
+   * @example
+   * // Basic pattern matching with different return types
+   * const result = fetchData();
+   * 
+   * const message = result.match({
+   *   ok: data => `Successfully loaded ${data.items.length} items`,
+   *   fail: error => `Error: ${error.message}`
+   * });
+   * 
+   * // Pattern matching for control flow
+   * result.match({
+   *   ok: data => {
+   *     renderData(data);
+   *     updateLastFetchTime();
+   *   },
+   *   fail: error => {
+   *     logError(error);
+   *     showRetryButton();
+   *   }
+   * });
+   * 
+   * // Pattern matching with transformations
+   * const apiResponse = makeApiCall()
+   *   .match({
+   *     ok: successResponse => ({ 
+   *       status: 'success', 
+   *       data: successResponse 
+   *     }),
+   *     fail: errorResponse => ({
+   *       status: 'error',
+   *       message: errorResponse.message,
+   *       code: errorResponse.code
+   *     })
+   *   });
+   */
   abstract match<M>(fn: IResultMatchPattern<TOk, TFail, M>): M
+
+  /**
+   * Maps the Ok value of this Result using the provided function.
+   * 
+   * If this Result is an Ok variant, this method transforms the contained value using
+   * the provided function and returns a new Ok Result with the transformed value.
+   * If this Result is a Fail variant, it returns a new Fail Result with the same error.
+   * 
+   * This operation is similar to Array.map but for a Result's Ok value.
+   * 
+   * @typeParam M - The type of the mapped value
+   * @param fn - A function that transforms the Ok value
+   * @returns A new Result with the transformed value if Ok, or the original error if Fail
+   * 
+   * @example
+   * // Transforming user data
+   * const userResult = fetchUser(userId);
+   * 
+   * const userProfileResult = userResult.map(user => ({
+   *   name: user.name,
+   *   email: user.email,
+   *   avatar: user.avatarUrl || 'default-avatar.png'
+   * }));
+   * 
+   * // Chaining multiple transformations
+   * const userNameResult = fetchUser(userId)
+   *   .map(user => user.profile)
+   *   .map(profile => profile.name)
+   *   .map(name => name.toUpperCase());
+   * 
+   * // Error case is automatically propagated
+   * const result = validate("invalid-input") // Returns Fail
+   *   .map(value => process(value))          // Map is not applied
+   *   .map(result => format(result));        // Map is not applied
+   * 
+   * // result is still the original Fail value
+   */
   abstract map<M>(fn: (val: TOk) => M): IResult<M, TFail>
+
+  /**
+   * Maps the Fail value of this Result using the provided function.
+   * 
+   * If this Result is a Fail variant, this method transforms the error using
+   * the provided function and returns a new Fail Result with the transformed error.
+   * If this Result is an Ok variant, it returns a new Ok Result with the same value.
+   * 
+   * This is useful for transforming errors while preserving their failure state.
+   * 
+   * @typeParam M - The type of the mapped error
+   * @param fn - A function that transforms the Fail value
+   * @returns A new Result with the transformed error if Fail, or the original value if Ok
+   * 
+   * @example
+   * // Enriching error information
+   * const result = fetchData()
+   *   .mapFail(error => ({
+   *     ...error,
+   *     timestamp: new Date(),
+   *     context: 'fetchData'
+   *   }));
+   * 
+   * // Converting between error types
+   * const standardizedResult = externalApiCall()
+   *   .mapFail(apiError => new AppError({
+   *     code: mapErrorCode(apiError.code),
+   *     message: apiError.message,
+   *     source: 'ExternalAPI'
+   *   }));
+   * 
+   * // Localizing error messages
+   * const localizedResult = validateInput(form)
+   *   .mapFail(errors => errors.map(err => ({
+   *     ...err,
+   *     message: translateErrorMessage(err.message, currentLocale)
+   *   })));
+   */
   abstract mapFail<M>(fn: (err: TFail) => M): IResult<TOk, M>
+
+  /**
+   * Chains a function that returns another Result.
+   * 
+   * If this Result is an Ok variant, this method applies the function to the contained value,
+   * which returns a new Result. This allows for sequencing operations that might fail.
+   * If this Result is a Fail variant, it returns a new Fail Result with the same error without
+   * calling the function.
+   * 
+   * This operation is similar to flatMap/bind in other functional programming contexts.
+   * 
+   * @typeParam M - The type of the value in the returned Result
+   * @param fn - A function that takes the Ok value and returns a new Result
+   * @returns The Result returned by fn if this Result is Ok, or a Fail Result with the original error
+   * 
+   * @example
+   * // Sequential operations that might fail
+   * const result = parseConfigFile(filePath)
+   *   .flatMap(config => validateConfig(config))
+   *   .flatMap(validConfig => initializeSystem(validConfig));
+   * 
+   * // Database transaction example
+   * const transactionResult = connectToDatabase()
+   *   .flatMap(connection => beginTransaction(connection))
+   *   .flatMap(transaction => executeQueries(transaction))
+   *   .flatMap(transaction => commitTransaction(transaction));
+   * 
+   * // Early return on failure
+   * const userResult = authenticateUser(credentials) // Might return Fail
+   *   .flatMap(user => authorizeUser(user, resource)) // Only called if authentication succeeds
+   *   .flatMap(user => loadUserProfile(user));        // Only called if authorization succeeds
+   */
   abstract flatMap<M>(fn: (val: TOk) => IResult<M, TFail>): IResult<M, TFail>
+  /**
+   * Maps the success value of this Result to a Maybe, and then flattens the resulting structure.
+   * 
+   * This method is particularly useful when working with optional properties or values that might be undefined/null.
+   * It allows for seamless chaining of Result and Maybe monads without explicit unwrapping and re-wrapping.
+   * 
+   * @typeParam M - The type of the value contained in the returned Result if successful
+   * @param fn - A function that takes the success value of this Result and returns a Maybe
+   * @param err - The error value to use if the Maybe is None
+   * @returns 
+   *   - If this Result is a Fail: A Fail Result containing the original error
+   *   - If this Result is an Ok and fn returns Some: An Ok Result containing the unwrapped value
+   *   - If this Result is an Ok but fn returns None: A Fail Result containing the provided err
+   * 
+   * @example
+   * // Type definitions
+   * interface User {
+   *   id: number;
+   *   profile?: {
+   *     name: string;
+   *     email: string;
+   *   };
+   * }
+   * 
+   * // Success path with Some
+   * const getUser = (): Result<User, Error> => 
+   *   ok({ id: 1, profile: { name: "Alice", email: "alice@example.com" } });
+   * 
+   * // Chain to access a potentially undefined property safely
+   * const getName = getUser()
+   *   .flatMapMaybe(
+   *     user => maybe(user.profile),
+   *     new Error("Profile not found")
+   *   )
+   *   .map(profile => profile.name);
+   * 
+   * // getName is Result<string, Error> containing "Alice"
+   * 
+   * // Using with nullish values
+   * type Response = { data?: { value: number } | null };
+   * 
+   * const response: Response = { data: null };
+   * const value = ok<Response, string>(response)
+   *   .flatMapMaybe(
+   *     res => maybe(res.data),
+   *     "No data available"
+   *   )
+   *   .flatMapMaybe(
+   *     data => maybe(data.value),
+   *     "Value not present"
+   *   );
+   * 
+   * // Working with arrays and optional chaining
+   * interface Post { comments?: Array<{ id: number, text: string }> }
+   * 
+   * const getFirstComment = (post: Post): Result<string, string> =>
+   *   ok(post)
+   *     .flatMapMaybe(
+   *       p => maybe(p.comments),
+   *       "No comments found"
+   *     )
+   *     .flatMapMaybe(
+   *       comments => maybe(comments[0]),
+   *       "Comment list is empty"
+   *     )
+   *     .map(comment => comment.text);
+   */
   abstract flatMapMaybe<M>(fn: (val: TOk) => IMaybe<M>, err: TFail): IResult<M, TFail>
+  /**
+   * Converts an Ok Result into a Fail Result using a transformation function.
+   * 
+   * This method inverts the Result's state by:
+   * - If this Result is an Ok variant, it applies the function to the contained value
+   *   to generate an error and returns a Fail Result with that error
+   * - If this Result is a Fail variant, it returns the original Fail Result unchanged
+   * 
+   * This is useful for scenarios where success conditions need to be converted to failures
+   * based on the content of the success value.
+   * 
+   * @param fn - A function that transforms the Ok value into a Fail value
+   * @returns A Fail Result with the generated error, or the original Fail Result
+   * 
+   * @example
+   * // Implementing validation logic
+   * const userResult = getUserById(userId);
+   * 
+   * const validatedUser = userResult.toFailWhenOk(user => {
+   *   if (!user.isActive) return new Error("User account is inactive");
+   *   if (user.accessLevel < requiredLevel) return new Error("Insufficient access level");
+   *   return null; // This case won't happen due to TypeScript's return type checking
+   * });
+   * 
+   * // Implementing business rule validation
+   * const orderResult = createOrder(orderData);
+   * 
+   * const validatedOrder = orderResult.toFailWhenOk(order => {
+   *   if (order.items.length === 0) return new ValidationError("Order must contain at least one item");
+   *   if (order.total < minimumOrderAmount) return new ValidationError(`Order total must be at least ${minimumOrderAmount}`);
+   *   return new ValidationError(""); // TypeScript requires a return, but this won't be reached in valid code
+   * });
+   */
   abstract toFailWhenOk(fn: (val: TOk) => TFail): IResult<TOk, TFail>
+
+  /**
+   * Converts an Ok Result into a Fail Result using a provided error value.
+   * 
+   * This method inverts the Result's state by:
+   * - If this Result is an Ok variant, it returns a Fail Result with the provided error
+   * - If this Result is a Fail variant, it returns a Fail Result with the provided error,
+   *   replacing the original error
+   * 
+   * This is useful for scenarios where you want to override or standardize error values.
+   * 
+   * @param val - The error value to use in the returned Fail Result
+   * @returns A Fail Result containing the provided error
+   * 
+   * @example
+   * // Standardizing error messages
+   * const result = parseInput(rawInput)
+   *   .toFailWhenOkFrom(new Error("Input validation failed"));
+   * 
+   * // Conditional error replacement
+   * let result = processData(data);
+   * 
+   * if (shouldUseStandardError) {
+   *   result = result.toFailWhenOkFrom(standardError);
+   * }
+   * 
+   * // Overriding authentication errors with a generic message
+   * const authResult = authenticate(credentials)
+   *   .toFailWhenOkFrom(new Error("Authentication failed"));
+   */
   abstract toFailWhenOkFrom(val: TFail): IResult<TOk, TFail>
-  abstract tap(val: IResultMatchPattern<TOk, TFail, void>): void
+
+  /**
+   * Executes side-effect functions based on the Result variant without changing the Result.
+   * 
+   * This method allows you to perform actions that don't affect the Result's value:
+   * - If this Result is an Ok variant, it calls the provided `ok` function with the contained value
+   * - If this Result is a Fail variant, it calls the provided `fail` function with the error
+   * 
+   * Both functions are optional; if not provided, nothing happens for that variant.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   * 
+   * @example
+   * // Logging based on Result variant
+   * fetchData().tap({
+   *   ok: data => console.log("Data fetched successfully:", data),
+   *   fail: error => console.error("Failed to fetch data:", error)
+   * });
+   * 
+   * // Metrics and analytics
+   * processPayment(paymentInfo).tap({
+   *   ok: result => {
+   *     analytics.trackEvent("payment_success", { 
+   *       amount: result.amount,
+   *       method: result.method
+   *     });
+   *   },
+   *   fail: error => {
+   *     analytics.trackEvent("payment_failure", { 
+   *       error: error.code,
+   *       message: error.message
+   *     });
+   *   }
+   * });
+   * 
+   * // Partial application (only handling one variant)
+   * validateInput(formData).tap({
+   *   fail: errors => highlightFormErrors(errors)
+   * });
+   */
+  abstract tap(val: Partial<IResultMatchPattern<TOk, TFail, void>>): void
+
+  /**
+   * Executes a side-effect function when this Result is an Ok variant.
+   * 
+   * This method is a specialized version of `tap` that only handles the Ok case:
+   * - If this Result is an Ok variant, it calls the provided function with the contained value
+   * - If this Result is a Fail variant, it does nothing
+   * 
+   * @param f - A function to execute with the Ok value
+   * 
+   * @example
+   * // Logging successful operations
+   * saveUser(userData).tapOk(user => {
+   *   console.log(`User ${user.id} saved successfully`);
+   *   updateLastSavedTimestamp();
+   * });
+   * 
+   * // UI updates on success
+   * fetchData().tapOk(data => {
+   *   updateUI(data);
+   *   hideLoadingIndicator();
+   * });
+   * 
+   * // Analytics for successful operations
+   * checkout(cart).tapOk(order => {
+   *   analytics.trackPurchase({
+   *     orderId: order.id,
+   *     amount: order.total,
+   *     items: order.items.length
+   *   });
+   * });
+   */
   abstract tapOk(f: (val: TOk) => void): void
+
+  /**
+   * Executes a side-effect function when this Result is a Fail variant.
+   * 
+   * This method is a specialized version of `tap` that only handles the Fail case:
+   * - If this Result is a Fail variant, it calls the provided function with the error
+   * - If this Result is an Ok variant, it does nothing
+   * 
+   * @param f - A function to execute with the Fail value
+   * 
+   * @example
+   * // Error logging
+   * processRequest(req).tapFail(error => {
+   *   logger.error("Request processing failed", {
+   *     error: error.message,
+   *     stack: error.stack,
+   *     requestId: req.id
+   *   });
+   * });
+   * 
+   * // UI error handling
+   * submitForm(formData).tapFail(errors => {
+   *   displayErrors(errors);
+   *   highlightInvalidFields(errors);
+   *   scrollToFirstError();
+   * });
+   * 
+   * // Monitoring and alerting
+   * criticalOperation().tapFail(error => {
+   *   if (error.severity === 'high') {
+   *     alertOps(error);
+   *     incrementFailureCounter();
+   *   }
+   * });
+   */
   abstract tapFail(f: (val: TFail) => void): void
+
+  /**
+   * Executes side-effect functions and returns the original Result for chaining.
+   * 
+   * This method is similar to `tap`, but returns the Result itself to allow for
+   * further method chaining:
+   * - If this Result is an Ok variant, it calls the provided `ok` function with the contained value
+   * - If this Result is a Fail variant, it calls the provided `fail` function with the error
+   * 
+   * Both functions are optional; if not provided, nothing happens for that variant.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   * @returns This Result, unchanged
+   * 
+   * @example
+   * // Chaining operations with logging
+   * return fetchUser(userId)
+   *   .tapThru({
+   *     ok: user => console.log(`User ${user.id} fetched`),
+   *     fail: err => console.error(`Failed to fetch user: ${err.message}`)
+   *   })
+   *   .map(user => transformUser(user))
+   *   .tapThru({
+   *     ok: profile => console.log(`User profile created`)
+   *   });
+   * 
+   * // Progressive UI updates in a chain
+   * processForm(data)
+   *   .tapThru({
+   *     ok: () => updateProgressBar(0.33)
+   *   })
+   *   .flatMap(validated => saveToDatabase(validated))
+   *   .tapThru({
+   *     ok: () => updateProgressBar(0.66),
+   *     fail: err => showErrorNotification(err)
+   *   })
+   *   .flatMap(saved => notifyUser(saved))
+   *   .tapThru({
+   *     ok: () => updateProgressBar(1.0),
+   *     fail: err => showErrorNotification(err)
+   *   });
+   */
   abstract tapThru(val: Partial<IResultMatchPattern<TOk, TFail, void>>): IResult<TOk, TFail>
+
+  /**
+   * Executes a side-effect function when this Result is an Ok variant and returns the original
+   * Result for chaining.
+   * 
+   * This method is a specialized version of `tapThru` that only handles the Ok case:
+   * - If this Result is an Ok variant, it calls the provided function with the contained value
+   * - If this Result is a Fail variant, it does nothing
+   * 
+   * In both cases, it returns the original Result unchanged.
+   * 
+   * @param fn - A function to execute with the Ok value
+   * @returns This Result, unchanged
+   * 
+   * @example
+   * // Chaining with logging for successful operations
+   * return getUserById(userId)
+   *   .tapOkThru(user => console.log(`Found user: ${user.name}`))
+   *   .map(user => user.profile)
+   *   .tapOkThru(profile => console.log(`Profile accessed`))
+   *   .flatMap(profile => getProfileSettings(profile.id));
+   * 
+   * // Progressive UI updates on success
+   * submitOrder(order)
+   *   .tapOkThru(() => {
+   *     showMessage("Order submitted");
+   *     updateProgressStep(1);
+   *   })
+   *   .flatMap(order => processPayment(order))
+   *   .tapOkThru(() => {
+   *     showMessage("Payment processed");
+   *     updateProgressStep(2);
+   *   })
+   *   .flatMap(order => finalizeOrder(order));
+   */
   abstract tapOkThru(fn: (val: TOk) => void): IResult<TOk, TFail>
+
+  /**
+   * Executes a side-effect function when this Result is a Fail variant and returns the original
+   * Result for chaining.
+   * 
+   * This method is a specialized version of `tapThru` that only handles the Fail case:
+   * - If this Result is a Fail variant, it calls the provided function with the error
+   * - If this Result is an Ok variant, it does nothing
+   * 
+   * In both cases, it returns the original Result unchanged.
+   * 
+   * @param fn - A function to execute with the Fail value
+   * @returns This Result, unchanged
+   * 
+   * @example
+   * // Chaining with error logging
+   * return validateInput(input)
+   *   .tapFailThru(errors => logValidationErrors(errors))
+   *   .flatMap(input => processInput(input))
+   *   .tapFailThru(error => logProcessingError(error))
+   *   .flatMap(result => saveResult(result));
+   * 
+   * // Progressive error handling
+   * authenticateUser(credentials)
+   *   .tapFailThru(error => {
+   *     logAuthFailure(error);
+   *     updateLoginAttempts();
+   *   })
+   *   .flatMap(user => authorizeUser(user, resource))
+   *   .tapFailThru(error => {
+   *     logAuthorizationFailure(error);
+   *     recordAccessAttempt(resource);
+   *   });
+   * 
+   * // Analytics tracking in a chain
+   * checkout(cart)
+   *   .tapFailThru(error => {
+   *     analytics.trackEvent("checkout_failure", {
+   *       error: error.code,
+   *       step: "initial_validation"
+   *     });
+   *   })
+   *   .flatMap(validCart => processPayment(validCart))
+   *   .tapFailThru(error => {
+   *     analytics.trackEvent("checkout_failure", {
+   *       error: error.code,
+   *       step: "payment_processing"
+   *     });
+   *   });
+   */
   abstract tapFailThru(fn: (val: TFail) => void): IResult<TOk, TFail>
 }
 
@@ -37,46 +729,146 @@ export class OkResult<TOk, TFail> extends Result<TOk, TFail> {
     super()
   }
 
+  /**
+   * Returns true as this is an Ok Result variant.
+   * 
+   * This implementation satisfies the abstract method from the Result class
+   * and serves as a TypeScript type guard, allowing TypeScript to narrow the 
+   * type to OkResult when `isOk()` returns true.
+   * 
+   * @returns true (always, for OkResult instances)
+   */
   isOk(): this is OkResult<TOk, TFail> {
     return true
   }
 
+  /**
+   * Returns false as this is not a Fail Result variant.
+   * 
+   * This implementation satisfies the abstract method from the Result class
+   * and serves as a TypeScript type guard that will never narrow the type
+   * to FailResult for an OkResult instance.
+   * 
+   * @returns false (always, for OkResult instances)
+   */
   isFail(): this is FailResult<TOk, TFail> {
     return false
   }
 
+  /**
+   * Extracts the contained Ok value.
+   * 
+   * Since this is an OkResult, this method safely returns the contained value
+   * without any risk of exceptions.
+   * 
+   * @returns The contained Ok value
+   */
   unwrap(): TOk {
     return this.successValue
   }
 
+  /**
+   * Extracts the contained Ok value or returns a default.
+   * 
+   * Since this is an OkResult, this method simply returns the contained
+   * value and ignores the default value parameter.
+   * 
+   * @param opt The default value (not used in OkResult implementation)
+   * @returns The contained Ok value
+   */
   unwrapOr(): TOk {
     return this.unwrap()
   }
 
+  /**
+   * Attempts to extract the contained Fail value, but throws since this is an OkResult.
+   * 
+   * This method is unsafe to call on an OkResult and will always throw an exception.
+   * 
+   * @throws ReferenceError Always throws with message 'Cannot unwrap a success as a failure'
+   * @returns Never returns a value, always throws
+   */
   unwrapFail(): never {
     throw new ReferenceError('Cannot unwrap a success as a failure')
   }
 
+  /**
+   * Converts this Ok Result to a Some Maybe containing the success value.
+   * 
+   * This method transforms the Ok Result into a Maybe, focusing on the success path.
+   * It always returns a Some Maybe for OkResult instances.
+   * 
+   * @returns A Some Maybe containing the non-nullable success value
+   */
   maybeOk(): IMaybe<NonNullable<TOk>> {
     return maybe(this.successValue as NonNullable<TOk>)
   }
 
+  /**
+   * Converts this Ok Result to a None Maybe.
+   * 
+   * This method transforms the Ok Result into a Maybe, focusing on the failure path.
+   * Since this is an OkResult with no error value, it always returns a None Maybe.
+   * 
+   * @returns A None Maybe (always, for OkResult instances)
+   */
   maybeFail(): IMaybe<TFail> {
     return none()
   }
 
+  /**
+   * Applies the success branch of a pattern matching object to this Ok Result.
+   * 
+   * This method provides a functional way to handle the Ok variant specifically.
+   * For OkResult instances, only the 'ok' function of the pattern is called.
+   * 
+   * @typeParam M - The return type of the pattern matching functions
+   * @param fn - An object containing functions to handle each Result variant
+   * @returns The result of applying the 'ok' function to the contained value
+   */
   match<M>(fn: IResultMatchPattern<TOk, TFail, M>): M {
     return fn.ok(this.successValue)
   }
 
+  /**
+   * Maps the Ok value using the provided function.
+   * 
+   * For OkResult instances, this transforms the contained value using the provided
+   * function and returns a new OkResult with the transformed value.
+   * 
+   * @typeParam M - The type of the mapped value
+   * @param fn - A function that transforms the Ok value
+   * @returns A new OkResult with the transformed value
+   */
   map<M>(fn: (val: TOk) => M): IResult<M, TFail> {
     return Result.ok<M, TFail>(fn(this.successValue))
   }
 
+  /**
+   * Maps the Fail value using the provided function, which is a no-op for OkResult.
+   * 
+   * For OkResult instances, this method ignores the mapping function since there is
+   * no error value to transform. It returns a new OkResult with the same success value
+   * but with the new error type parameter.
+   * 
+   * @typeParam M - The type of the mapped error (only changes the type parameter)
+   * @param fn - A function that would transform the Fail value (not used in OkResult)
+   * @returns A new OkResult with the same success value and updated error type
+   */
   mapFail<M>(): IResult<TOk, M> {
     return Result.ok(this.successValue)
   }
 
+  /**
+   * Chains a function that returns another Result, applying it to the contained value.
+   * 
+   * This is the monadic bind operation for Result. For OkResult instances, it applies
+   * the function to the contained value and returns the resulting Result directly.
+   * 
+   * @typeParam M - The type of the value in the returned Result
+   * @param fn - A function that takes the Ok value and returns a new Result
+   * @returns The Result returned by applying the function to the contained value
+   */
   flatMap<M>(fn: (val: TOk) => IResult<M, TFail>): IResult<M, TFail> {
     return fn(this.successValue)
   }
@@ -104,33 +896,99 @@ export class OkResult<TOk, TFail> extends Result<TOk, TFail> {
     })
   }
 
+  /**
+   * Converts this Ok Result into a Fail Result using a transformation function.
+   * 
+   * For OkResult instances, this method applies the function to the contained value
+   * to generate an error and returns a new Fail Result with that error.
+   * 
+   * @param fn - A function that transforms the Ok value into a Fail value
+   * @returns A Fail Result with the error generated from the contained value
+   */
   toFailWhenOk(fn: (val: TOk) => TFail): IResult<TOk, TFail> {
     return Result.fail(fn(this.successValue))
   }
 
+  /**
+   * Converts this Ok Result into a Fail Result using a provided error value.
+   * 
+   * For OkResult instances, this method ignores the contained value and returns
+   * a new Fail Result with the provided error value.
+   * 
+   * @param val - The error value to use in the returned Fail Result
+   * @returns A Fail Result containing the provided error
+   */
   toFailWhenOkFrom(val: TFail): IResult<TOk, TFail> {
     return Result.fail(val)
   }
 
+  /**
+   * Executes a side-effect function for this Ok Result.
+   * 
+   * For OkResult instances, this method calls the 'ok' function if provided.
+   * The 'fail' function is never called, even if provided.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   */
   tap(val: Partial<IResultMatchPattern<TOk, TFail, void>>): void {
     typeof val.ok === 'function' && val.ok(this.successValue)
   }
 
+  /**
+   * Executes a side-effect function with the contained Ok value.
+   * 
+   * For OkResult instances, this method always calls the provided function
+   * with the contained value.
+   * 
+   * @param fn - A function to execute with the Ok value
+   */
   tapOk(fn: (val: TOk) => void): void {
     fn(this.successValue)
   }
 
+  /**
+   * No-op method for consistency with the Result interface.
+   * 
+   * For OkResult instances, this method does nothing since there is no error
+   * value to operate on.
+   */
   tapFail(): void { }
   
+  /**
+   * No-op method that returns this Result for chaining.
+   * 
+   * For OkResult instances, this method simply returns the current Result
+   * without calling any function since there is no error value to operate on.
+   * 
+   * @returns This Result unchanged
+   */
   tapFailThru(): IResult<TOk, TFail> {
     return this
   }
 
+  /**
+   * Executes a side-effect function with the Ok value and returns this Result for chaining.
+   * 
+   * For OkResult instances, this method calls the provided function with the
+   * contained value and then returns the original Result unchanged.
+   * 
+   * @param fn - A function to execute with the Ok value
+   * @returns This Result unchanged
+   */
   tapOkThru(fn: (val: TOk) => void): IResult<TOk, TFail> {
     this.tapOk(fn)
     return this
   }
 
+  /**
+   * Executes a side-effect function and returns this Result for chaining.
+   * 
+   * For OkResult instances, this method calls the 'ok' function if provided
+   * and then returns the original Result unchanged.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   * @returns This Result unchanged
+   */
   tapThru(val: Partial<IResultMatchPattern<TOk, TFail, void>>): IResult<TOk, TFail> {
     this.tap(val)
     return this
@@ -142,46 +1000,147 @@ export class FailResult<TOk, TFail> extends Result<TOk, TFail> implements IResul
     super()
   }
 
+  /**
+   * Returns false as this is not an Ok Result variant.
+   * 
+   * This implementation satisfies the abstract method from the Result class
+   * and serves as a TypeScript type guard that will never narrow the type
+   * to OkResult for a FailResult instance.
+   * 
+   * @returns false (always, for FailResult instances)
+   */
   isOk(): this is OkResult<TOk, TFail> {
     return false
   }
 
+  /**
+   * Returns true as this is a Fail Result variant.
+   * 
+   * This implementation satisfies the abstract method from the Result class
+   * and serves as a TypeScript type guard, allowing TypeScript to narrow the
+   * type to FailResult when `isFail()` returns true.
+   * 
+   * @returns true (always, for FailResult instances)
+   */
   isFail(): this is FailResult<TOk, TFail> {
     return true
   }
 
+  /**
+   * Attempts to extract the contained Ok value, but throws since this is a FailResult.
+   * 
+   * This method is unsafe to call on a FailResult and will always throw an exception.
+   * 
+   * @throws Error Always throws with message 'Cannot unwrap a failure'
+   * @returns Never returns a value, always throws
+   */
   unwrap(): TOk {
     throw new Error('Cannot unwrap a failure')
   }
 
+  /**
+   * Extracts the contained Ok value or returns a default.
+   * 
+   * Since this is a FailResult, this method always returns the provided default
+   * value because there is no success value to extract.
+   * 
+   * @param opt The default value to return
+   * @returns The provided default value
+   */
   unwrapOr(opt: TOk): TOk {
     return opt
   }
 
+  /**
+   * Extracts the contained Fail value.
+   * 
+   * Since this is a FailResult, this method safely returns the contained error
+   * without any risk of exceptions.
+   * 
+   * @returns The contained Fail value
+   */
   unwrapFail(): TFail {
     return this.failureValue
   }
 
+  /**
+   * Converts this Fail Result to a None Maybe.
+   * 
+   * This method transforms the Fail Result into a Maybe, focusing on the success path.
+   * Since this is a FailResult with no success value, it always returns a None Maybe.
+   * 
+   * @returns A None Maybe (always, for FailResult instances)
+   */
   maybeOk(): IMaybe<NonNullable<TOk>> {
     return none()
   }
 
+  /**
+   * Converts this Fail Result to a Some Maybe containing the error value.
+   * 
+   * This method transforms the Fail Result into a Maybe, focusing on the failure path.
+   * It always returns a Some Maybe for FailResult instances.
+   * 
+   * @returns A Some Maybe containing the error value
+   */
   maybeFail(): IMaybe<TFail> {
     return maybe(this.failureValue)
   }
 
+  /**
+   * Applies the failure branch of a pattern matching object to this Fail Result.
+   * 
+   * This method provides a functional way to handle the Fail variant specifically.
+   * For FailResult instances, only the 'fail' function of the pattern is called.
+   * 
+   * @typeParam M - The return type of the pattern matching functions
+   * @param fn - An object containing functions to handle each Result variant
+   * @returns The result of applying the 'fail' function to the contained error
+   */
   match<M>(fn: IResultMatchPattern<TOk, TFail, M>): M {
     return fn.fail(this.failureValue)
   }
 
+  /**
+   * Maps the Fail value using the provided function.
+   * 
+   * For FailResult instances, this transforms the contained error using the provided
+   * function and returns a new FailResult with the transformed error.
+   * 
+   * @typeParam M - The type of the mapped error
+   * @param fn - A function that transforms the Fail value
+   * @returns A new FailResult with the transformed error
+   */
   mapFail<M>(fn: (err: TFail) => M): IResult<TOk, M> {
     return Result.fail(fn(this.failureValue))
   }
 
+  /**
+   * Maps the Ok value using the provided function, which is a no-op for FailResult.
+   * 
+   * For FailResult instances, this method ignores the mapping function since there is
+   * no success value to transform. It returns a new FailResult with the same error value
+   * but with the new success type parameter.
+   * 
+   * @typeParam M - The type of the mapped value (only changes the type parameter)
+   * @returns A new FailResult with the same error and updated success type
+   */
   map<M>(): IResult<M, TFail> {
     return Result.fail(this.failureValue)
   }
 
+  /**
+   * Chains a function that returns another Result, which is a no-op for FailResult.
+   * 
+   * For FailResult instances, this method ignores the mapping function since there
+   * is no success value to transform. It returns a new FailResult with the same error
+   * but with the new success type parameter.
+   * 
+   * This follows the monadic law that operations on failures should not execute the transformation.
+   * 
+   * @typeParam M - The type of the value in the returned Result (only changes the type parameter)
+   * @returns A FailResult with the same error and updated success type
+   */
   flatMap<M>(): IResult<M, TFail> {
     return Result.fail(this.failureValue)
   }
@@ -198,33 +1157,98 @@ export class FailResult<TOk, TFail> extends Result<TOk, TFail> implements IResul
     return Result.fail<M, TFail>(this.failureValue)
   }
 
+  /**
+   * No-op method for consistency with the Result interface.
+   * 
+   * For FailResult instances, this method simply returns the current Result
+   * unchanged since it's already a Fail variant.
+   * 
+   * @returns This Result unchanged
+   */
   toFailWhenOk(): IResult<TOk, TFail> {
     return this
   }
 
+  /**
+   * Converts this Fail Result into a new Fail Result with the provided error value.
+   * 
+   * For FailResult instances, this method returns a new Fail Result with the provided
+   * error value, replacing the original error.
+   * 
+   * @param val - The new error value to use
+   * @returns A Fail Result containing the provided error
+   */
   toFailWhenOkFrom(val: TFail): IResult<TOk, TFail> {
     return Result.fail(val)
   }
 
+  /**
+   * Executes a side-effect function for this Fail Result.
+   * 
+   * For FailResult instances, this method calls the 'fail' function if provided.
+   * The 'ok' function is never called, even if provided.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   */
   tap(val: Partial<IResultMatchPattern<TOk, TFail, void>>): void {
     typeof val.fail === 'function' && val.fail(this.failureValue)
   }
 
+  /**
+   * No-op method for consistency with the Result interface.
+   * 
+   * For FailResult instances, this method does nothing since there is no success
+   * value to operate on.
+   */
   tapOk(): void { }
 
+  /**
+   * Executes a side-effect function with the contained Fail value.
+   * 
+   * For FailResult instances, this method always calls the provided function
+   * with the contained error value.
+   * 
+   * @param fn - A function to execute with the Fail value
+   */
   tapFail(fn: (val: TFail) => void): void {
     fn(this.failureValue)
   }
 
+  /**
+   * Executes a side-effect function with the Fail value and returns this Result for chaining.
+   * 
+   * For FailResult instances, this method calls the provided function with the
+   * contained error value and then returns the original Result unchanged.
+   * 
+   * @param fn - A function to execute with the Fail value
+   * @returns This Result unchanged
+   */
   tapFailThru(fn: (val: TFail) => void): IResult<TOk, TFail> {
     this.tapFail(fn)
     return this
   }
 
+  /**
+   * No-op method that returns this Result for chaining.
+   * 
+   * For FailResult instances, this method simply returns the current Result
+   * without calling any function since there is no success value to operate on.
+   * 
+   * @returns This Result unchanged
+   */
   tapOkThru(): IResult<TOk, TFail> {
     return this
   }
 
+  /**
+   * Executes a side-effect function and returns this Result for chaining.
+   * 
+   * For FailResult instances, this method calls the 'fail' function if provided
+   * and then returns the original Result unchanged.
+   * 
+   * @param val - An object containing optional functions for Ok and Fail variants
+   * @returns This Result unchanged
+   */
   tapThru(val: Partial<IResultMatchPattern<TOk, TFail, void>>): IResult<TOk, TFail> {
     this.tap(val)
     return this


### PR DESCRIPTION
Introduced the flatMapMaybe method to the IResult interface and its implementations (OkResult and FailResult). This new method applies a function returning an IMaybe to the Ok value. If the function returns Some, it continues with Ok; if None, it results in a Fail with the specified error. If the original Result is a Fail, it remains unchanged. Accompanying tests verify behavior for both Ok and Fail scenarios. Additionally, updated package.json to specify pnpm as the package manager.